### PR TITLE
Modification du code source de cayenne

### DIFF
--- a/CayenneMQTT/src/CayenneArduinoMQTTClient.h
+++ b/CayenneMQTT/src/CayenneArduinoMQTTClient.h
@@ -54,25 +54,25 @@ public:
 	void connect() {
 		CAYENNE_LOG("Connecting to %s:%d", CAYENNE_DOMAIN, CAYENNE_PORT);
 		int error = MQTT_FAILURE;
-		int i = 0;
+		int timeoutCounter = 0;
 		do {
 			if (!NetworkConnect(&_network, CAYENNE_DOMAIN, CAYENNE_PORT)) {
-				if (i > 10) {
+				if (timeoutCounter > 15) {
 					CAYENNE_LOG("Network connect failed");
-					ESP.restart();
+					ESP.deepSleep(5e6); // 5e6 is 5 seconds				 Modify time to sleep for on error conencting here
 				}
 				delay(1000);
 			}
 			else if ((error = CayenneMQTTConnect(&_mqttClient)) != MQTT_SUCCESS) {
 											CAYENNE_LOG("MQTT connect failed, error %d", error);
 				NetworkDisconnect(&_network);
-				if (i > 10){
+				if (timeoutCounter > 15){
 					CAYENNE_LOG("Network connect failed");
-					ESP.restart();
+					ESP.deepSleep(5e6); // 5e6 is 5 seconds				 Modify time to sleep for on error conencting here
 				}
 				delay(1000);
 			}
-			i++;
+			timeoutCounter++;
 		}
 		while (error != MQTT_SUCCESS);
 

--- a/CayenneMQTT/src/CayenneMQTTWiFiClient.h
+++ b/CayenneMQTT/src/CayenneMQTTWiFiClient.h
@@ -57,12 +57,12 @@ public:
 		}
 		int timeoutCounter = 0;
 		while (WiFi.status() != WL_CONNECTED) {
-			timeoutCounter++;
 			CAYENNE_LOG("Not connected");
 			delay(100);
-			if (timeoutCounter > 5)
-				ESP.restart();
-			delay(500);
+			if (timeoutCounter > 15)
+				ESP.deepSleep(5e6); // 5e6 is 5 seconds				 Modify time to sleep for on error conencting here
+			delay(1000);
+			timeoutCounter++;
 		}
 		CAYENNE_LOG("Connected to WiFi");
 


### PR DESCRIPTION
Remplacement du ESP.restart par ESP.deepsleep dans les 2 fichiers.

Lors de plusieurs echecs de connexion, le esp deep sleep pour 5 secondes et se reboot.

************
LA PIN D0 DES NODEMCU DOIT ETRE CONNECTE A LA PIN RST
************

La raison d'utilisation de deepsleep au lieu de rst est pour pouvoir envoyer des updates via internet. ESP.restart a un bug ou il faut peser sur le bouton rst manuellement apres un flash de la carte.